### PR TITLE
V3.1.4 branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoloquent",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Mongoloquent is a lightweight MongoDB ORM library for Javascript/Typescript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -734,7 +734,7 @@ export default class Model<T> extends QueryBuilder<T> {
     const relation = new model();
 
     if (!foreignKey)
-      foreignKey = (relation.constructor.name.toLowerCase() + "Id") as keyof M;
+      foreignKey = (this.constructor.name.toLowerCase() + "Id") as keyof M;
     if (!localKey) localKey = "_id" as keyof T;
 
     const hasMany: IRelationHasMany = {
@@ -845,10 +845,10 @@ export default class Model<T> extends QueryBuilder<T> {
     const through = new throughModel();
 
     if (!foreignKey)
-      foreignKey = (relation.constructor.name.toLowerCase() + "Id") as keyof TM;
+      foreignKey = (this.constructor.name.toLowerCase() + "Id") as keyof TM;
     if (!foreignKeyThrough)
       foreignKeyThrough = (through.constructor.name.toLowerCase() +
-        "_id") as keyof M;
+        "Id") as keyof M;
 
     const hasManyThrough: IRelationHasManyThrough = {
       type: IRelationTypes.hasManyThrough,


### PR DESCRIPTION
This pull request includes a version bump for the `mongoloquent` package and fixes to the `Model` class to correct the generation of foreign key names in relationships. Below are the most important changes:

### Version Update:
* Updated the version in `package.json` from `3.1.3` to `3.1.4` to reflect the new changes.

### Bug Fixes in Foreign Key Generation:
* In the `Model` class (`src/Model.ts`), changed the foreign key generation logic to use the name of the current model (`this.constructor.name`) instead of the related model (`relation.constructor.name`) for `hasMany` relationships.
* Updated the foreign key generation logic for `hasManyThrough` relationships to use `this.constructor.name` for consistency and corrected the suffix from `"_id"` to `"Id"` for the `foreignKeyThrough` property.