### PR TITLE
Fix/with method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [3.7.1](https://github.com/ajatdarojat45/mongoloquent/compare/v3.7.0...v3.7.1) (2025-08-07)
+
+
+### Bug Fixes
+
+* add generic type parameter to static 'with' method in Model class ([380e422](https://github.com/ajatdarojat45/mongoloquent/commit/380e422fef7d45ba9b85ce4e7d1ac6f9f74d8b36))
+
 ## [3.7.0](https://github.com/ajatdarojat45/mongoloquent/compare/v3.6.0...v3.7.0) (2025-08-03)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "mongoloquent",
-	"version": "3.7.0",
+	"version": "3.7.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "mongoloquent",
-			"version": "3.7.0",
+			"version": "3.7.1",
 			"license": "MIT",
 			"dependencies": {
 				"dayjs": "^1.11.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mongoloquent",
-	"version": "3.7.0",
+	"version": "3.7.1",
 	"description": "Mongoloquent is a lightweight MongoDB ORM library for Javascript/Typescript",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/core/models/model.core.ts
+++ b/src/core/models/model.core.ts
@@ -406,7 +406,8 @@ export class Model<T = any> extends QueryBuilder<T> {
 		return this.query().sum(column);
 	}
 
-	public static with(
+	public static with<M extends typeof Model<any>>(
+		this: M,
 		relation: string | Record<string, string[]>,
 		options: IRelationshipOptions = {},
 	) {


### PR DESCRIPTION
This pull request releases version 3.7.1 of the `mongoloquent` library and addresses a bug related to TypeScript generics in the `Model` class. The most important changes are as follows:

### Bug Fix

* Added a generic type parameter to the static `with` method in the `Model` class to improve TypeScript type inference and ensure correct typing when using relationships.

### Release & Documentation

* Bumped the package version from `3.7.0` to `3.7.1` in `package.json` to reflect the new release.
* Updated `CHANGELOG.md` to document the bug fix and new version.