### PR TITLE
Feat/aggregate options in find method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [3.8.0](https://github.com/ajatdarojat45/mongoloquent/compare/v3.7.1...v3.8.0) (2025-08-08)
+
+
+### Features
+
+* add aggregate options support to find methods in QueryBuilder and AbstractQueryBuilder ([9117de2](https://github.com/ajatdarojat45/mongoloquent/commit/9117de256095b7ac0bf9efc576af97ac8859a52d))
+
 ### [3.7.1](https://github.com/ajatdarojat45/mongoloquent/compare/v3.7.0...v3.7.1) (2025-08-07)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "mongoloquent",
-	"version": "3.7.1",
+	"version": "3.8.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "mongoloquent",
-			"version": "3.7.1",
+			"version": "3.8.0",
 			"license": "MIT",
 			"dependencies": {
 				"dayjs": "^1.11.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mongoloquent",
-	"version": "3.7.1",
+	"version": "3.8.0",
 	"description": "Mongoloquent is a lightweight MongoDB ORM library for Javascript/Typescript",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/core/models/model.core.ts
+++ b/src/core/models/model.core.ts
@@ -1,4 +1,5 @@
 import {
+	AggregateOptions,
 	BulkWriteOptions,
 	FindOneAndUpdateOptions,
 	InsertOneOptions,
@@ -366,8 +367,9 @@ export class Model<T = any> extends QueryBuilder<T> {
 	public static find<M extends typeof Model<any>>(
 		this: M,
 		id: string | ObjectId,
+		options?: AggregateOptions,
 	): Promise<InstanceType<M>> {
-		return this.query().find(id) as Promise<InstanceType<M>>;
+		return this.query().find(id, options) as Promise<InstanceType<M>>;
 	}
 
 	public static async findOrFail(id: string | ObjectId) {

--- a/src/core/query-builders/abstract-query-builder.core.ts
+++ b/src/core/query-builders/abstract-query-builder.core.ts
@@ -1,4 +1,5 @@
 import {
+	AggregateOptions,
 	BulkWriteOptions,
 	DeleteOptions,
 	Document,
@@ -125,7 +126,10 @@ export abstract class AbstractQueryBuilder<T = WithId<Document>> {
 	public abstract firstOrFail<K extends keyof T>(
 		...columns: (K | K[])[]
 	): Promise<T>;
-	public abstract find(id: string | ObjectId): Promise<(this & T) | null>;
+	public abstract find(
+		id: string | ObjectId,
+		options: AggregateOptions,
+	): Promise<(this & T) | null>;
 	public abstract findOrFail(id: string | ObjectId): Promise<this & T>;
 
 	public abstract count(): Promise<number>;

--- a/src/core/query-builders/query-builder.core.ts
+++ b/src/core/query-builders/query-builder.core.ts
@@ -1,4 +1,5 @@
 import {
+	AggregateOptions,
 	BulkWriteOptions,
 	DeleteOptions,
 	Document,
@@ -61,6 +62,7 @@ export abstract class QueryBuilder<
 	private $limit: number = 0;
 	private $alias: string = "";
 	private $options: IRelationshipOptions = {};
+	private $aggregateOptions: AggregateOptions = {};
 
 	constructor() {
 		super();
@@ -348,9 +350,13 @@ export abstract class QueryBuilder<
 		return data as T;
 	}
 
-	public async find(id: string | ObjectId): Promise<(this & T) | null> {
+	public async find(
+		id: string | ObjectId,
+		options?: AggregateOptions,
+	): Promise<(this & T) | null> {
 		const _id = new ObjectId(id);
 		this.setId(_id);
+		if (options) this.setAggregateOptions(options);
 
 		let data = await this.get();
 		if (data && data.length > 0) {
@@ -950,11 +956,10 @@ export abstract class QueryBuilder<
 			this.generateConditionsForMongoDBQuery(true);
 			const nestedStages = this.getStages();
 
-			const aggregate = collection?.aggregate([
-				...stages,
-				...lookups,
-				...nestedStages,
-			]);
+			const aggregate = collection?.aggregate(
+				[...stages, ...lookups, ...nestedStages],
+				this.getAggregateOptions(),
+			);
 
 			this.resetQueryProperties();
 
@@ -1496,5 +1501,14 @@ export abstract class QueryBuilder<
 
 	public getOptions(): IRelationshipOptions {
 		return this.$options;
+	}
+
+	public setAggregateOptions(options: AggregateOptions): this {
+		this.$aggregateOptions = options;
+		return this;
+	}
+
+	public getAggregateOptions(): AggregateOptions {
+		return this.$aggregateOptions;
 	}
 }


### PR DESCRIPTION
This pull request introduces support for passing MongoDB aggregate options to the `find` methods in both `QueryBuilder` and `AbstractQueryBuilder`, enhancing query flexibility and control. The changes ensure that aggregate options can be set, retrieved, and utilized throughout the query-building process.

**Aggregate Options Support:**

* Added an optional `AggregateOptions` parameter to the `find` method in `Model`, `QueryBuilder`, and `AbstractQueryBuilder`, allowing users to specify MongoDB aggregation options when retrieving documents. [[1]](diffhunk://#diff-9eee23ef7dd16187eff58138568a25295c1cf9968f86db9cdd70794902e78f98R370-R372) [[2]](diffhunk://#diff-ce2898458c288d938729df50ec6973fc11c69acc3a07aece35b93af0afc5341aL128-R132) [[3]](diffhunk://#diff-d5a8c221b7e743ecae2248090685a9f1cb05a00b0a2e6da2eaba6ef7138f5455L351-R359)
* Implemented internal storage, setter, and getter for aggregate options (`$aggregateOptions`, `setAggregateOptions`, and `getAggregateOptions`) within `QueryBuilder`, and ensured these options are passed to the MongoDB aggregate call. [[1]](diffhunk://#diff-d5a8c221b7e743ecae2248090685a9f1cb05a00b0a2e6da2eaba6ef7138f5455R65) [[2]](diffhunk://#diff-d5a8c221b7e743ecae2248090685a9f1cb05a00b0a2e6da2eaba6ef7138f5455L953-R962) [[3]](diffhunk://#diff-d5a8c221b7e743ecae2248090685a9f1cb05a00b0a2e6da2eaba6ef7138f5455R1505-R1513)

**Versioning and Documentation:**

* Updated `package.json` to version `3.8.0` to reflect the new feature.
* Added a changelog entry describing the addition of aggregate options support to the find methods.