### PR TITLE
Feat/enhance transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [3.8.2](https://github.com/ajatdarojat45/mongoloquent/compare/v3.8.1...v3.8.2) (2025-08-14)
+
 ### [3.8.1](https://github.com/ajatdarojat45/mongoloquent/compare/v3.8.0...v3.8.1) (2025-08-13)
 
 

--- a/__tests__/relationships/belongsToMany/attach.test.ts
+++ b/__tests__/relationships/belongsToMany/attach.test.ts
@@ -1,11 +1,4 @@
-import {
-	IMongoloquentSchema,
-	IMongoloquentSoftDelete,
-	IMongoloquentTimestamps,
-	Model,
-	DB,
-	MongoloquentNotFoundException,
-} from "../../../src/";
+import { IMongoloquentSchema, Model, DB } from "../../../src/";
 beforeEach(async () => {
 	await DB.collection("users").getMongoDBCollection().deleteMany({});
 	await DB.collection("roles").getMongoDBCollection().deleteMany({});
@@ -79,7 +72,9 @@ describe("attach method", () => {
 		const user = await User.find(userIds[0]);
 		await user.roles().attach<{
 			additional: string;
-		}>(roleIds[0], { additional: "value" });
+		}>(roleIds[0], {
+			doc: { additional: "value" },
+		});
 
 		const roles = await user.roles().get();
 		expect(roles.length).toBe(1);

--- a/__tests__/relationships/belongsToMany/sync.test.ts
+++ b/__tests__/relationships/belongsToMany/sync.test.ts
@@ -90,7 +90,9 @@ describe("sync method", () => {
 
 		await user.roles().sync<{
 			additional: string;
-		}>([roleIds[0], roleIds[1]], { additional: "value" });
+		}>([roleIds[0], roleIds[1]], {
+			doc: { additional: "value" },
+		});
 		const rolesAfterDetach = await user.roles().get();
 		expect(rolesAfterDetach.length).toBe(2);
 

--- a/__tests__/relationships/belongsToMany/syncWithPivotValues.test.ts
+++ b/__tests__/relationships/belongsToMany/syncWithPivotValues.test.ts
@@ -68,7 +68,9 @@ describe("syncWithPivotValues method", () => {
 
 		await user.roles().syncWithPivotValues<{
 			additional: string;
-		}>([roleIds[0], roleIds[1]], { additional: "value" });
+		}>([roleIds[0], roleIds[1]], {
+			doc: { additional: "value" },
+		});
 
 		const rolesAfterDetach = await user.roles().get();
 		expect(rolesAfterDetach.length).toBe(2);

--- a/__tests__/relationships/belongsToMany/syncWithoutDetaching.test.ts
+++ b/__tests__/relationships/belongsToMany/syncWithoutDetaching.test.ts
@@ -88,7 +88,7 @@ describe("syncWithoutDetaching method", () => {
 		await user.roles().syncWithoutDetaching<{
 			additional: string;
 		}>([roleIds[1], roleIds[2]], {
-			additional: "value",
+			doc: { additional: "value" },
 		});
 		const rolesAfterDetach = await user.roles().get();
 		expect(rolesAfterDetach.length).toBe(3);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "mongoloquent",
-	"version": "3.8.1",
+	"version": "3.8.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "mongoloquent",
-			"version": "3.8.1",
+			"version": "3.8.2",
 			"license": "MIT",
 			"dependencies": {
 				"dayjs": "^1.11.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mongoloquent",
-	"version": "3.8.1",
+	"version": "3.8.2",
 	"description": "Mongoloquent is a lightweight MongoDB ORM library for Javascript/Typescript",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/core/query-builders/abstract-query-builder.core.ts
+++ b/src/core/query-builders/abstract-query-builder.core.ts
@@ -26,6 +26,7 @@ export abstract class AbstractQueryBuilder<T = WithId<Document>> {
 	protected abstract $useTimestamps: boolean;
 	protected abstract $useSoftDelete: boolean;
 	protected abstract $attributes: Partial<T>;
+	protected abstract $hidden: (keyof T)[];
 
 	public abstract select<K extends keyof T>(
 		...columns: (K | (string & {}) | (K | (string & {}))[])[]
@@ -215,67 +216,99 @@ export abstract class AbstractQueryBuilder<T = WithId<Document>> {
 
 	public abstract setTimezone(timezone: string): this;
 	public abstract getTimezone(): string;
+
 	public abstract setConnection(connection: string): this;
 	public abstract getConnection(): string;
+
 	public abstract setDatabaseName(name: string): this;
 	public abstract getDatabaseName(): string;
+
 	public abstract setCollection(collection: string): this;
 	public abstract getCollection(): string;
+
 	public abstract setUseTimestamps(useTimestamps: boolean): this;
 	public abstract getUseTimestamps(): boolean;
+
 	public abstract setUseSoftDelete(useSoftDelete: boolean): this;
 	public abstract getUseSoftDelete(): boolean;
+
+	public abstract setHidden<K extends keyof T>(
+		...columns: (K | (string & {}) | (K | (string & {}))[])[]
+	): this;
+	public abstract addHidden(column: keyof T): this;
+	public abstract getHidden(): (keyof T)[];
+
 	public abstract setCreatedAt(createdAt: string): this;
 	public abstract getCreatedAt(): string;
+
 	public abstract setUpdatedAt(updatedAt: string): this;
 	public abstract getUpdatedAt(): string;
+
 	public abstract setStages(documents: Document[]): this;
 	public abstract addStage(document: Document): this;
 	public abstract getStages(): Document[];
+
 	public abstract setColumns<K extends keyof T>(
 		...columns: (K | (string & {}) | (K | (string & {}))[])[]
 	): this;
 	public abstract addColumn(column: keyof T): this;
 	public abstract getColumns(): (keyof T)[];
+
 	public abstract setExcludes<K extends keyof T>(
 		...columns: (K | (string & {}) | (K | (string & {}))[])[]
 	): this;
 	public abstract addExclude(column: keyof T): this;
 	public abstract getExcludes(): (keyof T)[];
+
 	public abstract setWheres(wheres: IQueryBuilderWhere[]): this;
 	public abstract addWhere(where: IQueryBuilderWhere): this;
 	public abstract getWheres(): IQueryBuilderWhere[];
+
 	public abstract setOrders(orders: IQueryBuilderOrder[]): this;
 	public abstract addOrder(order: IQueryBuilderOrder): this;
 	public abstract getOrders(): IQueryBuilderOrder[];
+
 	public abstract setGroups(columns: (keyof T)[]): this;
 	public abstract addGroup(column: keyof T): this;
 	public abstract getGroups(): (keyof T)[];
+
 	public abstract setWithTrashed(withTrashed: boolean): this;
 	public abstract getWithTrashed(): boolean;
+
 	public abstract setOnlyTrashed(onlyTrashed: boolean): this;
 	public abstract getOnlyTrashed(): boolean;
+
 	public abstract setOffset(offset: number): this;
 	public abstract getOffset(): number;
+
 	public abstract setId(id: ObjectId | string | null): this;
 	public abstract getId(): ObjectId | string | null;
+
 	public abstract setOriginal(original: Partial<T>): this;
 	//public abstract getOriginal(): Partial<T>
+
 	public abstract setChanges(changes: Partial<Record<keyof T, any>>): this;
 	// public abstract getChanges(): Partial<Record<keyof T, any>>
+
 	public abstract setLookups(lookups: Document[]): this;
 	public abstract addLookup(lookup: Document): this;
 	public abstract getLookups(): Document[];
+
 	public abstract setIsDeleted(isDeleted: string): this;
 	public abstract getIsDeleted(): string;
+
 	public abstract setDeletedAt(deletedAt: string): this;
 	public abstract getDeletedAt(): string;
+
 	public abstract setLimit(limit: number): this;
 	public abstract getLimit(): number;
+
 	public abstract setAttributes(attributes: Partial<T>): this;
 	public abstract getAttributes(): Partial<T>;
+
 	public abstract setAlias(alias: string): this;
 	public abstract getAlias(): string;
+
 	public abstract setOptions(options: IRelationshipOptions): this;
 	public abstract getOptions(): IRelationshipOptions;
 }

--- a/src/relationships/has-many.relationship.ts
+++ b/src/relationships/has-many.relationship.ts
@@ -1,4 +1,4 @@
-import { Document } from "mongodb";
+import { BulkWriteOptions, Document, InsertOneOptions } from "mongodb";
 import {
 	IQueryBuilderFormSchema,
 	IQueryBuilderPaginated,
@@ -38,63 +38,66 @@ export class HasMany<T = any, M = any> extends QueryBuilder<M> {
 	public firstOrNew(
 		filter: Partial<IQueryBuilderFormSchema<M>>,
 		doc?: Partial<IQueryBuilderFormSchema<M>>,
+		options?: InsertOneOptions,
 	): Promise<M> {
 		const _filter = {
 			...filter,
 			[this.foreignKey]: this.model["$original"][this.localKey],
 		} as IQueryBuilderFormSchema<M>;
-		return super.firstOrNew(_filter, doc);
+		return super.firstOrNew(_filter, doc, options);
 	}
 
 	public firstOrCreate(
 		filter: Partial<IQueryBuilderFormSchema<M>>,
 		doc?: Partial<IQueryBuilderFormSchema<M>>,
+		options?: InsertOneOptions,
 	): Promise<M> {
 		const _filter = {
 			...filter,
 			[this.foreignKey]: this.model["$original"][this.localKey],
 		} as IQueryBuilderFormSchema<M>;
-		return super.firstOrCreate(_filter, doc);
+		return super.firstOrCreate(_filter, doc, options);
 	}
 
 	public updateOrCreate(
 		filter: Partial<IQueryBuilderFormSchema<M>>,
 		doc: Partial<IQueryBuilderFormSchema<M>>,
+		options?: InsertOneOptions,
 	) {
 		const _filter = {
 			...filter,
 			[this.foreignKey]: this.model["$original"][this.localKey],
 		} as IQueryBuilderFormSchema<M>;
-		return super.updateOrCreate(_filter, doc);
+		return super.updateOrCreate(_filter, doc, options);
 	}
 
 	// @ts-ignore
-	public save(doc: Partial<M>): Promise<M> {
+	public save(doc: Partial<M>, options?: InsertOneOptions): Promise<M> {
 		const data = {
 			...doc,
 			[this.foreignKey]: this.model["$original"][this.localKey],
 		} as IQueryBuilderFormSchema<M>;
 
-		return this.insert(data);
+		return this.insert(data, options);
 	}
 
-	public saveMany(docs: Partial<M>[]) {
+	public saveMany(docs: Partial<M>[], options?: BulkWriteOptions) {
 		const data = docs.map((doc) => ({
 			...doc,
 			[this.foreignKey]: this.model["$original"][this.localKey],
 		})) as IQueryBuilderFormSchema<M>[];
 
-		return this.insertMany(data);
+		return this.insertMany(data, options);
 	}
 
 	// @ts-ignore
-	public create(doc: Partial<M>): Promise<M> {
-		return this.save(doc);
+	public create(doc: Partial<M>, options?: InsertOneOptions): Promise<M> {
+		return this.save(doc, options);
 	}
 
 	// @ts-ignore
-	public createMany(docs: Partial<M>[]) {
-		return this.saveMany(docs);
+	public createMany(docs: Partial<M>[], options?: BulkWriteOptions) {
+		return this.saveMany(docs, options);
 	}
 
 	public all(): Promise<Collection<M>> {

--- a/src/relationships/morph-many.relationship.ts
+++ b/src/relationships/morph-many.relationship.ts
@@ -1,4 +1,10 @@
-import { Document, ObjectId, WithId } from "mongodb";
+import {
+	BulkWriteOptions,
+	Document,
+	InsertOneOptions,
+	ObjectId,
+	WithId,
+} from "mongodb";
 import {
 	Collection,
 	IQueryBuilderFormSchema,
@@ -35,18 +41,20 @@ export class MorphMany<T = any, M = any> extends QueryBuilder<M> {
 	public firstOrNew(
 		filter: Partial<IQueryBuilderFormSchema<M>>,
 		doc?: Partial<IQueryBuilderFormSchema<M>>,
+		options?: InsertOneOptions,
 	): Promise<M> {
 		const _filter = {
 			...filter,
 			[this.morphType]: this.model.constructor.name,
 			[this.morphId]: (this.model["$original"] as any)["_id"],
 		} as IQueryBuilderFormSchema<M>;
-		return super.firstOrNew(_filter, doc);
+		return super.firstOrNew(_filter, doc, options);
 	}
 
 	public firstOrCreate(
 		filter: Partial<IQueryBuilderFormSchema<M>>,
 		doc?: Partial<IQueryBuilderFormSchema<M>>,
+		options?: InsertOneOptions,
 	): Promise<M> {
 		const _filter = {
 			...filter,
@@ -54,12 +62,13 @@ export class MorphMany<T = any, M = any> extends QueryBuilder<M> {
 			[this.morphId]: (this.model["$original"] as any)["_id"],
 		} as IQueryBuilderFormSchema<M>;
 
-		return super.firstOrCreate(_filter, doc);
+		return super.firstOrCreate(_filter, doc, options);
 	}
 
 	public updateOrCreate(
 		filter: Partial<IQueryBuilderFormSchema<M>>,
 		doc?: Partial<IQueryBuilderFormSchema<M>>,
+		options?: InsertOneOptions,
 	): Promise<M | WithId<IQueryBuilderFormSchema<M>>> {
 		const _filter = {
 			...filter,
@@ -67,22 +76,26 @@ export class MorphMany<T = any, M = any> extends QueryBuilder<M> {
 			[this.morphId]: (this.model["$original"] as any)["_id"],
 		} as IQueryBuilderFormSchema<M>;
 
-		return super.updateOrCreate(_filter, doc);
+		return super.updateOrCreate(_filter, doc, options);
 	}
 
 	// @ts-ignore
-	public save(doc: Partial<IQueryBuilderFormSchema<M>>): Promise<M> {
+	public save(
+		doc: Partial<IQueryBuilderFormSchema<M>>,
+		options?: InsertOneOptions,
+	): Promise<M> {
 		const data = {
 			...doc,
 			[this.morphType]: this.model.constructor.name,
 			[this.morphId]: (this.model["$original"] as any)["_id"],
 		} as IQueryBuilderFormSchema<M>;
 
-		return this.insert(data);
+		return this.insert(data, options);
 	}
 
 	public saveMany(
 		docs: Partial<IQueryBuilderFormSchema<M>>[],
+		options?: BulkWriteOptions,
 	): Promise<ObjectId[]> {
 		const data = docs.map((doc) => ({
 			...doc,
@@ -90,19 +103,23 @@ export class MorphMany<T = any, M = any> extends QueryBuilder<M> {
 			[this.morphId]: (this.model["$original"] as any)["_id"],
 		})) as IQueryBuilderFormSchema<M>[];
 
-		return this.insertMany(data);
+		return this.insertMany(data, options);
 	}
 
 	// @ts-ignore
-	public create(doc: Partial<IQueryBuilderFormSchema<M>>): Promise<M> {
-		return this.save(doc);
+	public create(
+		doc: Partial<IQueryBuilderFormSchema<M>>,
+		options?: InsertOneOptions,
+	): Promise<M> {
+		return this.save(doc, options);
 	}
 
 	// @ts-ignore
 	public createMany(
 		docs: Partial<IQueryBuilderFormSchema<M>>[],
+		options?: BulkWriteOptions,
 	): Promise<ObjectId[]> {
-		return this.saveMany(docs);
+		return this.saveMany(docs, options);
 	}
 
 	public all(): Promise<Collection<M>> {


### PR DESCRIPTION
This pull request introduces support for hiding fields in query results and improves how options are passed to pivot operations in the `BelongsToMany` relationship. It also updates tests to reflect these API changes and bumps the package version. The main changes are grouped below.

### Query Builder Enhancements

* Added support for hidden fields in `AbstractQueryBuilder` and `QueryBuilder` via a new `$hidden` property and corresponding methods (`setHidden`, `addHidden`, `getHidden`). This allows users to exclude specified fields from query results without affecting selected columns. [[1]](diffhunk://#diff-ce2898458c288d938729df50ec6973fc11c69acc3a07aece35b93af0afc5341aR29) [[2]](diffhunk://#diff-d5a8c221b7e743ecae2248090685a9f1cb05a00b0a2e6da2eaba6ef7138f5455R44) [[3]](diffhunk://#diff-d5a8c221b7e743ecae2248090685a9f1cb05a00b0a2e6da2eaba6ef7138f5455R1301-R1323)
* Implemented `generateHiddenForMongoDBQuery` to build `$project` stages for hidden fields in aggregation pipelines, ensuring hidden fields are excluded from results.
* Refactored the aggregation pipeline construction in pagination and query methods to incorporate hidden fields and improve stage handling. [[1]](diffhunk://#diff-d5a8c221b7e743ecae2248090685a9f1cb05a00b0a2e6da2eaba6ef7138f5455L254-R283) [[2]](diffhunk://#diff-d5a8c221b7e743ecae2248090685a9f1cb05a00b0a2e6da2eaba6ef7138f5455L941-L965)

### BelongsToMany Relationship API Improvements

* Changed the API for `attach`, `sync`, `syncWithoutDetaching`, and `syncWithPivotValues` methods to accept an options object (with `doc` and MongoDB options), allowing more flexible pivot document insertion and update. [[1]](diffhunk://#diff-d7834232b1354ee413abca3d918f2c5becd1bedb006bca1ce8364486310b8d00L107-R121) [[2]](diffhunk://#diff-d7834232b1354ee413abca3d918f2c5becd1bedb006bca1ce8364486310b8d00L183-R204) [[3]](diffhunk://#diff-d7834232b1354ee413abca3d918f2c5becd1bedb006bca1ce8364486310b8d00L241-R269) [[4]](diffhunk://#diff-d7834232b1354ee413abca3d918f2c5becd1bedb006bca1ce8364486310b8d00L294-R329)
* Updated internal calls to pass MongoDB options to `insertMany`, `restore`, and `delete` operations for better control over bulk operations. [[1]](diffhunk://#diff-d7834232b1354ee413abca3d918f2c5becd1bedb006bca1ce8364486310b8d00L151-R168) [[2]](diffhunk://#diff-d7834232b1354ee413abca3d918f2c5becd1bedb006bca1ce8364486310b8d00L222-R253) [[3]](diffhunk://#diff-d7834232b1354ee413abca3d918f2c5becd1bedb006bca1ce8364486310b8d00L280-R312) [[4]](diffhunk://#diff-d7834232b1354ee413abca3d918f2c5becd1bedb006bca1ce8364486310b8d00R178) [[5]](diffhunk://#diff-d7834232b1354ee413abca3d918f2c5becd1bedb006bca1ce8364486310b8d00L174-R188)

### Test Suite Updates

* Modified tests for `attach`, `sync`, `syncWithPivotValues`, and `syncWithoutDetaching` methods to use the new options object format, ensuring compatibility with the updated API. [[1]](diffhunk://#diff-7ee6fc3b2e37a7101f6a4628701f8d42b341c4e2031ff2b424cab53c33f415a5L82-R77) [[2]](diffhunk://#diff-1d194e2d7242927eb7ed38a5a079778620906b94656f217a896cb0c16f86681bL93-R95) [[3]](diffhunk://#diff-3ed62ee40061043801c9f255e08edc75c504df801b61cec632093cb312f86abdL71-R73) [[4]](diffhunk://#diff-5a9b3b0dd3a8cf3ef2cbbeb92caf574d6c5628e095f937de8039ecb154203189L91-R91)
* Cleaned up imports in the test files to reflect unused interfaces.

### Maintenance

* Bumped the package version to `3.8.2` in `package.json` and updated the changelog. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R6)