### PR TITLE
feat: set connection and database name in pivot model

### DIFF
--- a/src/core/models/model.core.ts
+++ b/src/core/models/model.core.ts
@@ -696,6 +696,8 @@ export class Model<T = any> extends QueryBuilder<T> {
 
 		const pivot = Model.query();
 		pivot.setCollection(collection);
+		pivot.setConnection(this.$connection);
+		pivot.setDatabaseName(this.$databaseName);
 
 		if (!foreignPivotKey)
 			foreignPivotKey = (this.constructor.name.toLowerCase() +


### PR DESCRIPTION
This pull request updates the pivot query logic in the `Model` class to ensure that pivot queries use the same database connection and database name as the parent model. This change helps maintain consistency and prevents issues when working with multiple connections or databases.

**Pivot query consistency:**

* Updated the `Model` class in `model.core.ts` to set the connection and database name on pivot queries by calling `setConnection` and `setDatabaseName` with the current model's values.